### PR TITLE
Fix jsbundles API group

### DIFF
--- a/server/services/plugin.js
+++ b/server/services/plugin.js
@@ -3,7 +3,7 @@ const { sendGatewayRequest } = require('../libs/request');
 
 const getInstalledExtensions = async ctx => {
   try {
-    const url = '/apis/kubesphere.io/v1alpha1/jsbundles';
+    const url = '/apis/extensions.kubesphere.io/v1alpha1/jsbundles';
     const extensions = await sendGatewayRequest({
       method: 'GET',
       url,


### PR DESCRIPTION
Extension Management API Goup Version: `/apis/kubesphere.io/v1alpha1`
Extension Management API Resources: `extensions`,`extensionversions`,`categories`,`repositories`,`subscriptions`


Extension API Goup Version: `/apis/extensions.kubesphere.io/v1alpha1`
Extension API Resources: `apiservices`,`jsbundles`,`everseproxies`

```release-note
None
```